### PR TITLE
Add missing includes for Tensor

### DIFF
--- a/include/tensor/tensor.tpp
+++ b/include/tensor/tensor.tpp
@@ -4,6 +4,8 @@
 #include <utility> // std::move
 #include <memory>  // std::unique_ptr
 #include <cstdlib> // std::free
+#include <cassert>
+#include <cstdint>
 
 #ifdef __GNUG__
 #include <cxxabi.h> // abi::__cxa_demangle


### PR DESCRIPTION
## Summary
- add `<cassert>` and `<cstdint>` headers to `tensor.tpp` to support assert and uintptr_t use

## Testing
- `cmake -S . -B build_debug -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build_debug`
- `cmake -S . -B build_release -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build_release`


------
https://chatgpt.com/codex/tasks/task_e_68c1b4aa45f88325a7d43abc8f33e9e4